### PR TITLE
Lighthouse Reports with Runfiles Paths

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -44,6 +44,7 @@ wasm_deps = [
     "@wasm_crates//:serde",
     "@wasm_crates//:wasm-bindgen",
     "@wasm_crates//:web-sys",
+    "@rules_rust//tools/runfiles",
 ]
 
 rust_shared_library(

--- a/src/components/dev.rs
+++ b/src/components/dev.rs
@@ -1,8 +1,12 @@
 use crate::components::source_anchor::SourceAnchor;
 use leptos::prelude::*;
+use runfiles::{rlocation, Runfiles};
 
 #[component]
 pub fn Lighthouse() -> impl IntoView {
+    let r = Runfiles::create().expect("Must run using bazel with runfiles");
+    let assets_path = rlocation!(r, "_main/assets").expect("Failed to locate main");
+
     view! {
         <div>
             "Here is a programmatically generated lighthouse report "
@@ -16,7 +20,7 @@ pub fn Lighthouse() -> impl IntoView {
             </a> "that gets kicked off as part of a k8s job for every new deploy of this site."
         </div>
         <iframe
-            src="/assets/lighthouse.html"
+            src=format!("{}/lighthouse.html", assets_path.to_string_lossy())
             title="Lighthouse Report"
             class="grow w-full"
         ></iframe>

--- a/src/routes/lighthouse/post.rs
+++ b/src/routes/lighthouse/post.rs
@@ -1,3 +1,5 @@
+use runfiles::{rlocation, Runfiles};
+
 #[cfg(feature = "ssr")]
 #[derive(thiserror::Error, Debug)]
 pub enum LighthouseError {
@@ -55,12 +57,16 @@ pub async fn upload_lighthouse_report(
     if credentials.is_err() {
         return Ok(HttpResponse::BadRequest().finish());
     }
+
     log::info!("Valid credentials upload_lighthouse_report");
+
+    let r = Runfiles::create().expect("Must run using bazel with runfiles");
+    let assets_path = rlocation!(r, "_main/assets").expect("Failed to locate main");
 
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .write(true)
-        .open("site/lighthouse.html")?;
+        .open(format!("{}/lighthouse.html", assets_path.to_string_lossy()))?;
 
     let mut file_contents: Vec<u8> = Vec::new();
     while let Some(item) = payload.next().await {


### PR DESCRIPTION
With Bazel migration we broke the lighthouse file saving/rendering. This fixes that by using the runfiles paths