### PR TITLE
Quickfix: Remove Target Compat

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -123,10 +123,6 @@ oci_image(
         ":jaydanhoward_tar",
     ],
     workdir = "/app/jaydanhoward_bin.runfiles",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
 )
 
 oci_image(
@@ -137,10 +133,6 @@ oci_image(
         ":jaydanhoward_tar",
     ],
     workdir = "/app/jaydanhoward_bin.runfiles",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:arm64",
-    ],
 )
 
 oci_image_index(


### PR DESCRIPTION
Since the image push target depends on these two and gets run on x86 the target compat was causing the push target to get skipped in https://github.com/jaydh/jaydanhoward/actions/runs/12513134471
That's unfortunate, so I'm removing the target compat int he hopes that the push can get the artifacts from the remote cache and put both images in the oci_index. 
Seems like an unfortunate consequence of oci_image_index dependencies. Will have to investigate cross-compiling (but I'm not sure you can cross-build images without some kind of qemu in the loop)