### PR TITLE
Push Multi-Arch Images with Separate Tags

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -131,7 +131,6 @@ jobs:
       - name: Push Index List
         run: docker manifest push harbor.home.local/library/jaydanhoward:latest
   harbor-ligthouse-image:
-    if: github.event_name == 'push'
     name: Build lighthouse image
     runs-on: arc-runner-set
     container: ${{ vars.RUNNER_IMAGE_URL }}
@@ -149,6 +148,31 @@ jobs:
           registry: harbor.home.local
           username: ${{ secrets.HARBOR_USER}}
           password: ${{ secrets.HARBOR_TOKEN}}
-      - name: BuildAndPushImageOnHarbor
+      - name: Build Image
         run: "docker build -t harbor.home.local/library/lighthouse:latest .\ndocker push harbor.home.local/library/lighthouse:latest \n"
+        working-directory: lighthouse
+  harbor-ligthouse-image-push:
+    if: github.event_name == 'push'
+    name: Push lighthouse image
+    runs-on: arc-runner-set
+    container: ${{ vars.RUNNER_IMAGE_URL }}
+    needs: [clippy]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: harbor.home.local
+          username: ${{ secrets.HARBOR_USER}}
+          password: ${{ secrets.HARBOR_TOKEN}}
+      - name: Build Image
+        run: docker build -t harbor.home.local/library/lighthouse:latest .
+        working-directory: lighthouse
+      - name: Push Image
+        run: docker push harbor.home.local/library/lighthouse:latest
         working-directory: lighthouse

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -83,7 +83,7 @@ jobs:
   harbor-image-arm64-push:
     if: github.event_name == 'push'
     needs: [harbor-image-arm64]
-    name: Push JDH - arm64
+    name: Push JDH Image - arm64
     runs-on: arc-runner-set-k8s
     container: ${{ vars.RUNNER_IMAGE_URL }}
     steps:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -156,7 +156,7 @@ jobs:
     name: Push lighthouse image
     runs-on: arc-runner-set
     container: ${{ vars.RUNNER_IMAGE_URL }}
-    needs: [clippy, harbor-ligthouse-image]
+    needs: [harbor-ligthouse-image]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -156,7 +156,7 @@ jobs:
     name: Push lighthouse image
     runs-on: arc-runner-set
     container: ${{ vars.RUNNER_IMAGE_URL }}
-    needs: [clippy]
+    needs: [clippy, harbor-ligthouse-image]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Bazel Push
         run: |
           bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64
-  harbor-image-list-push:
+  harbor-image-arm64-push:
     if: github.event_name == 'push'
     needs: [harbor-image-arm64]
     name: Push JDH Image - arm64
@@ -100,7 +100,7 @@ jobs:
       - name: Bazel Push
         run: |
           bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64_push
-  harbor-ligthouse-image:
+  harbor-image-list-push:
     if: github.event_name == 'push'
     name: Push JDH Multi-arch Image
     runs-on: arc-runner-set

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -46,7 +46,7 @@ jobs:
     name: Push JDH Image - x86_64
     runs-on: arc-runner-set-k8s
     container: ${{ vars.RUNNER_IMAGE_URL }}
-    needs: [clippy, harbor-image-x86_64]
+    needs: [harbor-image-x86_64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -102,6 +102,36 @@ jobs:
           bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64_push
   harbor-ligthouse-image:
     if: github.event_name == 'push'
+    name: Build JDH Multi-arch Image
+    runs-on: arc-runner-set
+    container: ${{ vars.RUNNER_IMAGE_URL }}
+    needs: [harbor-image-x86_64-push, harbor-image-arm64-push]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: harbor.home.local
+          username: ${{ secrets.HARBOR_USER}}
+          password: ${{ secrets.HARBOR_TOKEN}}
+      - name: Pull New Images
+        run: |
+          docker pull harbor.home.local/library/jaydanhoward:latest-arm64
+          docker pull harbor.home.local/library/jaydanhoward:latest-amd64
+      - name: Create Index List
+        run: |
+          docker manifest create harbor.home.local/library/jaydanhoward:latest \
+            harbor.home.local/library/jaydanhoward:latest-arm64 --arch arm64 --os linux \
+            harbor.home.local/library/jaydanhoward:latest-amd64 ----arch amd64 --os linux
+      - name: Push Index List
+        run: docker manifest push harbor.home.local/library/jaydanhoward:latest
+  harbor-ligthouse-image:
+    if: github.event_name == 'push'
     name: Build lighthouse image
     runs-on: arc-runner-set
     container: ${{ vars.RUNNER_IMAGE_URL }}

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -41,11 +41,12 @@ jobs:
       - name: Bazel Build
         run: |
           bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_amd64
-  harbor-image-arm64:
-    name: Build JDH Image - arm64
-    runs-on: arc-runner-set-arm-k8s
+  harbor-image-x86_64-push:
+    if: github.event_name == 'push'
+    name: Push JDH Image - x86_64
+    runs-on: arc-runner-set-k8s
     container: ${{ vars.RUNNER_IMAGE_URL }}
-    needs: [clippy]
+    needs: [clippy, harbor-image-x86_64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,11 +60,10 @@ jobs:
           password: ${{ secrets.HARBOR_TOKEN}}
       - name: Bazel Build
         run: |
-          bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64
-  harbor-image-index:
-    if: github.event_name == 'push'
-    needs: [harbor-image-arm64, harbor-image-x86_64]
-    name: Push JDH Multi-arch Image
+          bazel --bazelrc=.bazelrc.ci run jaydanhoward_image_amd64_push
+  harbor-image-arm64:
+    needs: [clippy]
+    name: Build JDH - arm64
     runs-on: arc-runner-set-k8s
     container: ${{ vars.RUNNER_IMAGE_URL }}
     steps:
@@ -79,7 +79,27 @@ jobs:
           password: ${{ secrets.HARBOR_TOKEN}}
       - name: Bazel Push
         run: |
-          bazel --bazelrc=.bazelrc.ci run jaydanhoward_image_push
+          bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64
+  harbor-image-arm64-push:
+    if: github.event_name == 'push'
+    needs: [harbor-image-arm64, harbor-image-x86_64]
+    name: Push JDH - arm64
+    runs-on: arc-runner-set-k8s
+    container: ${{ vars.RUNNER_IMAGE_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Login to Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: harbor.home.local
+          username: ${{ secrets.HARBOR_USER}}
+          password: ${{ secrets.HARBOR_TOKEN}}
+      - name: Bazel Push
+        run: |
+          bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64_push
   harbor-ligthouse-image:
     if: github.event_name == 'push'
     name: Build lighthouse image

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -63,7 +63,7 @@ jobs:
           bazel --bazelrc=.bazelrc.ci run jaydanhoward_image_amd64_push
   harbor-image-arm64:
     needs: [clippy]
-    name: Build JDH - arm64
+    name: Build JDH Image - arm64
     runs-on: arc-runner-set-k8s
     container: ${{ vars.RUNNER_IMAGE_URL }}
     steps:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -82,7 +82,7 @@ jobs:
           bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64
   harbor-image-arm64-push:
     if: github.event_name == 'push'
-    needs: [harbor-image-arm64, harbor-image-x86_64]
+    needs: [harbor-image-arm64]
     name: Push JDH - arm64
     runs-on: arc-runner-set-k8s
     container: ${{ vars.RUNNER_IMAGE_URL }}

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Bazel Push
         run: |
           bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64
-  harbor-image-arm64-push:
+  harbor-image-list-push:
     if: github.event_name == 'push'
     needs: [harbor-image-arm64]
     name: Push JDH Image - arm64
@@ -102,7 +102,7 @@ jobs:
           bazel --bazelrc=.bazelrc.ci build jaydanhoward_image_arm64_push
   harbor-ligthouse-image:
     if: github.event_name == 'push'
-    name: Build JDH Multi-arch Image
+    name: Push JDH Multi-arch Image
     runs-on: arc-runner-set
     container: ${{ vars.RUNNER_IMAGE_URL }}
     needs: [harbor-image-x86_64-push, harbor-image-arm64-push]

--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,7 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_shared_library", "rust_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_rust_wasm_bindgen//rules_js:defs.bzl", "js_rust_wasm_bindgen", )
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push", "oci_image_index")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push", "oci_image_index",)
 load("@rules_rust//rust:defs.bzl", "rust_clippy")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -143,26 +143,20 @@ oci_image(
     ],
 )
 
-oci_image_index(
-    name = "jaydanhoward_image",
-    images = [
-        ":jaydanhoward_image_amd64",
-        ":jaydanhoward_image_arm64",
-    ]
-)
-
-oci_load(
-    name = "jaydanhoward_image_load",
-    image = ":jaydanhoward_image",
-    repo_tags = ["harbor.home.local/library/jaydanhoward:latest"]
+oci_push(
+    name = "jaydanhoward_image_amd64_push",
+    image = ":jaydanhoward_image_amd64",
+    repository = "harbor.home.local/library/jaydanhoward",
+    remote_tags = ["latest-amd64"]
 )
 
 oci_push(
-    name = "jaydanhoward_image_push",
-    image = ":jaydanhoward_image",
+    name = "jaydanhoward_image_arm64_push",
+    image = ":jaydanhoward_image_arm64",
     repository = "harbor.home.local/library/jaydanhoward",
-    remote_tags = ["latest"]
+    remote_tags = ["latest-arm64"]
 )
+
 
 rust_clippy(
     name = "clippy",

--- a/BUILD
+++ b/BUILD
@@ -123,6 +123,10 @@ oci_image(
         ":jaydanhoward_tar",
     ],
     workdir = "/app/jaydanhoward_bin.runfiles",
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 oci_image(
@@ -133,6 +137,10 @@ oci_image(
         ":jaydanhoward_tar",
     ],
     workdir = "/app/jaydanhoward_bin.runfiles",
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
 )
 
 oci_image_index(

--- a/BUILD
+++ b/BUILD
@@ -123,10 +123,6 @@ oci_image(
         ":jaydanhoward_tar",
     ],
     workdir = "/app/jaydanhoward_bin.runfiles",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
 )
 
 oci_image(
@@ -137,10 +133,6 @@ oci_image(
         ":jaydanhoward_tar",
     ],
     workdir = "/app/jaydanhoward_bin.runfiles",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:arm64",
-    ],
 )
 
 oci_image_index(

--- a/BUILD
+++ b/BUILD
@@ -117,7 +117,7 @@ pkg_tar(
 
 oci_image(
     name = "jaydanhoward_image_amd64",
-    base = "@distroless_cc",
+    base = "@distroless_cc_linux_amd64",
     entrypoint = ["/app/jaydanhoward_bin"],
     tars = [
         ":jaydanhoward_tar",
@@ -127,7 +127,7 @@ oci_image(
 
 oci_image(
     name = "jaydanhoward_image_arm64",
-    base = "@distroless_cc",
+    base = "@distroless_cc_linux_arm64_v8",
     entrypoint = ["/app/jaydanhoward_bin"],
     tars = [
         ":jaydanhoward_tar",

--- a/BUILD
+++ b/BUILD
@@ -123,6 +123,10 @@ oci_image(
         ":jaydanhoward_tar",
     ],
     workdir = "/app/jaydanhoward_bin.runfiles",
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 oci_image(
@@ -133,6 +137,10 @@ oci_image(
         ":jaydanhoward_tar",
     ],
     workdir = "/app/jaydanhoward_bin.runfiles",
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
 )
 
 oci_push(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,22 +18,22 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 http_file(
     name = "tailwind_linux_x86_64",
     executable = True,
+    sha256 = "33f254b54c8754f16efbe2be1de38ca25192630dc36f164595a770d4bbf4d893",
     url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.16/tailwindcss-linux-x64",
-    sha256 = "33f254b54c8754f16efbe2be1de38ca25192630dc36f164595a770d4bbf4d893"
 )
 
 http_file(
     name = "tailwind_linux_arm64",
     executable = True,
+    sha256 = "1e6746bba6f3d34d7550889a1a009ab90ee3794a5ebce60ed10688ad10680a87",
     url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.16/tailwindcss-linux-arm64",
-    sha256 = "1e6746bba6f3d34d7550889a1a009ab90ee3794a5ebce60ed10688ad10680a87"
 )
 
 http_file(
     name = "tailwind_mac_arm64",
     executable = True,
+    sha256 = "a1d0c7985759accca0bf12e51ac1dcbf0f6cf2fffb62e6e0f62d091c477a10a3",
     url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.17/tailwindcss-macos-arm64",
-    sha256 = "a1d0c7985759accca0bf12e51ac1dcbf0f6cf2fffb62e6e0f62d091c477a10a3"
 )
 
 http_archive(
@@ -60,7 +60,6 @@ http_archive(
     urls = ["https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.99/wasm-bindgen-0.2.99-aarch64-apple-darwin.tar.gz"],
 )
 
-
 bazel_dep(name = "rules_oci", version = "2.2.0")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
@@ -73,7 +72,6 @@ oci.pull(
     ],
     tag = "latest",
 )
-
 oci.pull(
     name = "distroless_cc",
     image = "gcr.io/distroless/cc",
@@ -84,4 +82,4 @@ oci.pull(
     tag = "latest",
 )
 
-use_repo(oci, "distroless_base", "distroless_cc")
+use_repo(oci, "distroless_base", "distroless_base_linux_amd64", "distroless_base_linux_arm64_v8", "distroless_cc", "distroless_cc_linux_amd64", "distroless_cc_linux_arm64_v8")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -249,7 +249,7 @@
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "iJZZ9aBHnYHHAy1nTAK++jt2xuVOmEK880oZBsgVW3I=",
-        "usagesDigest": "3x8DbRztS/ZpbiSi6K02ZsauOyMrPiKgoyWh8El7jqA=",
+        "usagesDigest": "+r9HPSGUWpmRTIMWwNeslSCtt/GA1CUFoWwshgTvcY8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -266,6 +266,18 @@
               "bazel_tags": []
             }
           },
+          "distroless_base_linux_arm64_v8": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/base",
+              "identifier": "latest",
+              "platform": "linux/arm64/v8",
+              "target_name": "distroless_base_linux_arm64_v8",
+              "bazel_tags": []
+            }
+          },
           "distroless_base": {
             "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
             "attributes": {
@@ -275,7 +287,8 @@
               "repository": "distroless/base",
               "identifier": "latest",
               "platforms": {
-                "@@platforms//cpu:x86_64": "@distroless_base_linux_amd64"
+                "@@platforms//cpu:x86_64": "@distroless_base_linux_amd64",
+                "@@platforms//cpu:arm64": "@distroless_base_linux_arm64_v8"
               },
               "bzlmod_repository": "distroless_base",
               "reproducible": true
@@ -293,6 +306,18 @@
               "bazel_tags": []
             }
           },
+          "distroless_cc_linux_arm64_v8": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/cc",
+              "identifier": "latest",
+              "platform": "linux/arm64/v8",
+              "target_name": "distroless_cc_linux_arm64_v8",
+              "bazel_tags": []
+            }
+          },
           "distroless_cc": {
             "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
             "attributes": {
@@ -302,7 +327,8 @@
               "repository": "distroless/cc",
               "identifier": "latest",
               "platforms": {
-                "@@platforms//cpu:x86_64": "@distroless_cc_linux_amd64"
+                "@@platforms//cpu:x86_64": "@distroless_cc_linux_amd64",
+                "@@platforms//cpu:arm64": "@distroless_cc_linux_arm64_v8"
               },
               "bzlmod_repository": "distroless_cc",
               "reproducible": true
@@ -655,8 +681,10 @@
           "explicitRootModuleDirectDeps": [
             "distroless_base",
             "distroless_base_linux_amd64",
+            "distroless_base_linux_arm64_v8",
             "distroless_cc",
-            "distroless_cc_linux_amd64"
+            "distroless_cc_linux_amd64",
+            "distroless_cc_linux_arm64_v8"
           ],
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",


### PR DESCRIPTION
https://github.com/bazel-contrib/rules_oci/issues/228 
There doesn't seem to be a good way to build multi-arch images all within rules_oci atm. New strategy is to push images tagged with their arch as separate images, and have a follow up PR/workflow step that _pulls_ them from remote and hopefully can put them into an image index